### PR TITLE
fix(render): rendering food in the menu

### DIFF
--- a/public/js/app/ff.js
+++ b/public/js/app/ff.js
@@ -34,105 +34,105 @@ ff.defaultItems = function () {
     defaultItems[0].name = "Hamburguesa";
     defaultItems[0].cost = -25;
     defaultItems[0].price = 35;
-    defaultItems[0].ico = defaultItems[0].texture;
+    defaultItems[0].ico = "core:menu:food-item:hamburguer";
 
     defaultItems[1].name = "Papas fritas";
     defaultItems[1].desc = "Descripción de las papas fritas";
     defaultItems[1].cost = -10;
     defaultItems[1].price = 20;
-    defaultItems[1].ico = defaultItems[1].texture;
+    defaultItems[1].ico = "core:menu:food-item:fries";
 
     defaultItems[2].name = "Perro caliente";
     defaultItems[2].cost = -20;
     defaultItems[2].price = 37;
-    defaultItems[2].ico = defaultItems[2].texture;
+    defaultItems[2].ico = "core:menu:food-item:hot-dog";
 
     defaultItems[3].name = "Pan tostado";
     defaultItems[3].cost = -8;
     defaultItems[3].price = 17;
-    defaultItems[3].ico = defaultItems[3].texture;
+    defaultItems[3].ico = "core:menu:food-item:toast";
 
     defaultItems[4].name = "Dona";
     defaultItems[4].cost = -8;
     defaultItems[4].price = 16;
-    defaultItems[4].ico = defaultItems[4].texture;
+    defaultItems[4].ico = "core:menu:food-item:doughnut";
 
     defaultItems[5].name = "Huevos fritos";
     defaultItems[5].cost = -9;
     defaultItems[5].price = 13;
-    defaultItems[5].ico = defaultItems[5].texture;
+    defaultItems[5].ico = "core:menu:food-item:egg";
 
     defaultItems[6].name = "Queso";
     defaultItems[6].cost = -6;
     defaultItems[6].price = 10;
-    defaultItems[6].ico = defaultItems[6].texture;
+    defaultItems[6].ico = "core:menu:food-item:cheese";
 
     defaultItems[7].name = "Pescado frito";
     defaultItems[7].cost = -20;
     defaultItems[7].price = 36;
-    defaultItems[7].ico = defaultItems[7].texture;
+    defaultItems[7].ico = "core:menu:food-item:fish";
 
     //---------MEDIUM
     defaultItems[8].name = "Sandwich";
     defaultItems[8].cost = -30;
     defaultItems[8].price = 47;
-    defaultItems[8].ico = defaultItems[8].texture;
+    defaultItems[8].ico = "core:menu:food-item:sandwich";
 
     defaultItems[9].name = "Muslos de pollo";
     defaultItems[9].cost = -40;
     defaultItems[9].price = 58;
-    defaultItems[9].ico = defaultItems[9].texture;
+    defaultItems[9].ico = "core:menu:food-item:meat";
 
     defaultItems[10].name = "Pizza";
     defaultItems[10].cost = -70;
     defaultItems[10].price = 100;
-    defaultItems[10].ico = defaultItems[10].texture;
+    defaultItems[10].ico = "core:menu:food-item:pizza";
 
     defaultItems[11].name = "Camarones";
     defaultItems[11].cost = -100;
     defaultItems[11].price = 177;
-    defaultItems[11].ico = defaultItems[11].texture;
+    defaultItems[11].ico = "core:menu:food-item:shrimp";
 
     defaultItems[12].name = "Shawarma";
     defaultItems[12].cost = -50;
     defaultItems[12].price = 70;
-    defaultItems[12].ico = defaultItems[12].texture;
+    defaultItems[12].ico = "core:menu:food-item:kebab";
 
     defaultItems[13].name = "Croissant";
     defaultItems[13].cost = -48;
     defaultItems[13].price = 67;
-    defaultItems[13].ico = defaultItems[13].texture;
+    defaultItems[13].ico = "core:menu:food-item:croissant";
 
     defaultItems[14].name = "Bistec";
     defaultItems[14].cost = -65;
     defaultItems[14].price = 80;
-    defaultItems[14].ico = defaultItems[14].texture;
+    defaultItems[14].ico = "core:menu:food-item:steak";
 
     defaultItems[15].name = "Galletas";
     defaultItems[15].cost = -50;
     defaultItems[15].price = 77;
-    defaultItems[15].ico = defaultItems[15].texture;
+    defaultItems[15].ico = "core:menu:food-item:cookies";
 
     //--------HIGH
     defaultItems[16].name = "Ensalada";
     defaultItems[16].cost = -120;
     defaultItems[16].price = 148;
-    defaultItems[16].ico = defaultItems[16].texture;
+    defaultItems[16].ico = "core:menu:food-item:salad";
 
     defaultItems[17].name = "Sushi";
     defaultItems[17].cost = -250;
     defaultItems[17].price = 300;
-    defaultItems[17].ico = defaultItems[17].texture;
+    defaultItems[17].ico = "core:menu:food-item:sushi";
 
     defaultItems[18].name = "Panquecas";
     defaultItems[18].cost = -100;
     defaultItems[18].price = 120;
-    defaultItems[18].ico = defaultItems[18].texture;
+    defaultItems[18].ico = "core:menu:food-item:pancakes";
 
     defaultItems[19].name = "Salami";
     defaultItems[19].cost = -110;
     defaultItems[19].price = 180;
-    defaultItems[19].ico = defaultItems[19].texture;
+    defaultItems[19].ico = "core:menu:food-item:salami";
 
     return defaultItems;
 };

--- a/src/components/menu.ts
+++ b/src/components/menu.ts
@@ -1,29 +1,29 @@
 import type { Component } from "./component";
 
 export enum FoodItemTexturesEnum {
-    HAMBURGER = "core:food-item:hamburguer",
-    FRIES = "core:food-item:fries",
-    HOT_DOG = "core:food-item:hot-dog",
-    TOAST = "core:food-item:toast",
-    DOUGHNUT = "core:food-item:doughnut",
-    EGG = "core:food-item:egg",
-    CHEESE = "core:food-item:cheese",
-    FISH = "core:food-item:fish",
-    SANDWICH = "core:food-item:sandwich",
-    MEAT = "core:food-item/meat",
-    PIZZA = "core:food-item:pizza",
-    SHRIMP = "core:food-item:shrimp",
-    KEBAB = "core:food-item:kebab",
-    CROISSANT = "core:food-item:croissant",
-    STEAK = "core:food-item:steak",
-    COOKIES = "core:food-item:cookies",
-    SALAD = "core:food-item:salad",
-    SUSHI = "core:food-item:sushi",
-    PANCAKES = "core:food-item:pancakes",
-    SALAMI = "core:food-item:salami",
+    HAMBURGER = "core:menu:food-item:hamburguer",
+    FRIES = "core:menu:food-item:fries",
+    HOT_DOG = "core:menu:food-item:hot-dog",
+    TOAST = "core:menu:food-item:toast",
+    DOUGHNUT = "core:menu:food-item:doughnut",
+    EGG = "core:menu:food-item:egg",
+    CHEESE = "core:menu:food-item:cheese",
+    FISH = "core:menu:food-item:fish",
+    SANDWICH = "core:menu:food-item:sandwich",
+    MEAT = "core:menu:food-item:meat",
+    PIZZA = "core:menu:food-item:pizza",
+    SHRIMP = "core:menu:food-item:shrimp",
+    KEBAB = "core:menu:food-item:kebab",
+    CROISSANT = "core:menu:food-item:croissant",
+    STEAK = "core:menu:food-item:steak",
+    COOKIES = "core:menu:food-item:cookies",
+    SALAD = "core:menu:food-item:salad",
+    SUSHI = "core:menu:food-item:sushi",
+    PANCAKES = "core:menu:food-item:pancakes",
+    SALAMI = "core:menu:food-item:salami",
 }
 
-export const foodItemComponent: Component = {
+export const menuComponent: Component = {
     loadTextures(addTexture) {
         addTexture(
             FoodItemTexturesEnum.HAMBURGER,

--- a/src/engines/client.ts
+++ b/src/engines/client.ts
@@ -17,10 +17,6 @@ export class ClientController {
         this.list.push(client);
 
         this.quantity++;
-        console.log(
-            "New client generated. at delta: " +
-                this.deltaSinceLastGenerationAttempt,
-        );
         this.deltaSinceLastGenerationAttempt = 0;
 
         return client;
@@ -43,7 +39,6 @@ export class ClientController {
             config.clientRandom == true &&
             randomNumber(1, 100) > config.clientRandomChance
         ) {
-            console.log("failed random chance");
             this.deltaSinceLastGenerationAttempt = 0;
             return false;
         }

--- a/src/engines/textures.ts
+++ b/src/engines/textures.ts
@@ -42,7 +42,7 @@ function addTexture(id: string, textureUrl: string) {
         return;
     }
 
-    const idRegex = /^[a-zA-Z0-9_]+(:[a-zA-Z0-9_]+)*$/;
+    const idRegex = /^[a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*$/;
     if (!idRegex.test(id)) {
         console.error(
             `Texture id \`${id}\` is not valid. It should be defined by an string that can be prefixed by any nested amount of scopes separated by colons. e.g. "core:hearts", "client:avatar:{id}"`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,14 @@ import { gameLoop } from "./engines/game-loop";
 import { renderAll, createRenderable } from "./libs/render-x";
 import { applyUpdates, f } from "./libs/flexbones";
 import { config } from "./master.config";
-import { addTexture, textures } from "./engines/textures";
+import { addTexture } from "./engines/textures";
 import { clientComponent } from "./components/client";
 import { healthBarComponent } from "./components/health-bar";
 import { loadRenderablesHealthBar } from "./renderables/health-bar";
 import { starsBarComponent } from "./components/stars-bar";
 import { loadRenderablesStarsBar } from "./renderables/stars-bar";
+import { menuComponent } from "./components/menu";
+import { loadRenderablesMenu } from "./renderables/menu";
 
 /**
  * FIXME: This is code from the early migration of the engines to the new codebase
@@ -20,7 +22,6 @@ import { loadRenderablesStarsBar } from "./renderables/stars-bar";
  */
 globalThis.client = clientsEngine;
 globalThis.config = config;
-globalThis.textures = textures;
 
 // END OF ENGINES MIGRATION
 
@@ -32,6 +33,7 @@ assets.set(ff.defaultAsset);
 clientComponent.loadTextures(addTexture);
 healthBarComponent.loadTextures(addTexture);
 starsBarComponent.loadTextures(addTexture);
+menuComponent.loadTextures(addTexture);
 
 //------- WE SET ITEMS IN INVENTORY
 for (let i = 0; i < 20; i++) {
@@ -44,6 +46,7 @@ scene.setup();
 // FIXME: MOVE ME TO A BETTER PLACE
 loadRenderablesHealthBar();
 loadRenderablesStarsBar();
+loadRenderablesMenu();
 
 createRenderable(
     "player_name",
@@ -79,28 +82,15 @@ createRenderable(
     },
 );
 
-const fpsElement: HTMLElement =
-    paint.getContext("ff-gamePrint-fps")[0]?.children[0];
-
 gameLoop.addDrawStep(() => {
-    if (fpsElement) {
-        fpsElement.innerHTML = `${Math.round(gameLoop.fps)} fps`;
-    }
+    applyUpdates(
+        f(null, `${Math.round(gameLoop.fps)} fps`),
+        ".ff-gamePrint-fps > :nth-child(1)",
+    );
 });
 
 gameLoop.addDrawStep(() => {
-    //We update the print renders.
-    if (render.print.checkMemory("stars", game.state.player.stars) == false) {
-        render.print.stars(game.state.player.stars);
-    }
-    if (render.print.checkMemory("money", game.state.player.money) == false) {
-        render.print.money(game.state.player.money);
-    }
-
     //We update the scene renders.
-    if (render.scene.checkMemory("menu", game.state.scene.menu) == false) {
-        render.scene.menu(game.state.scene.menu);
-    }
     if (render.scene.checkMemory("hand", game.state.player.hand) == false) {
         render.scene.hand(game.state.player.hand);
     }

--- a/src/libs/flexbones.ts
+++ b/src/libs/flexbones.ts
@@ -200,8 +200,13 @@ export function f(
     return xElementDescription;
 }
 
-type XContext = HTMLElement | HTMLElement[] | NodeListOf<Element> | string;
-type ResolvedXContext = HTMLElement[] | NodeListOf<Element>;
+type XContext =
+    | HTMLElement
+    | HTMLElement[]
+    | Element
+    | NodeListOf<Element>
+    | string;
+type ResolvedXContext = Element[] | HTMLElement[] | NodeListOf<Element>;
 
 export function resolveContext(context: XContext): ResolvedXContext {
     let contextElements: ResolvedXContext;
@@ -209,7 +214,10 @@ export function resolveContext(context: XContext): ResolvedXContext {
     if (typeof context === "string") {
         contextElements = document.querySelectorAll(context);
     } else {
-        contextElements = context instanceof HTMLElement ? [context] : context;
+        contextElements =
+            context instanceof HTMLElement || context instanceof Element
+                ? [context]
+                : context;
     }
 
     if (contextElements.length === 0) {

--- a/src/renderables/menu.ts
+++ b/src/renderables/menu.ts
@@ -1,0 +1,39 @@
+import { createRenderable } from "../libs/render-x";
+import { applyUpdates, f } from "../libs/flexbones";
+import { textures } from "../engines/textures";
+
+export function loadRenderablesMenu(): void {
+    createRenderable("menu", game.state.scene.menu, ({ newState }) => {
+        console.log(newState);
+        // we get the all references in one go, for performance
+        const menuSlots = document.querySelectorAll(".ff-gameMenu-slot");
+
+        for (let i = 0; i < newState.length; i++) {
+            const menuItem = newState[i];
+            const menuItemSlot = menuSlots[i];
+            const menuItemTexture = `url(${textures.get(menuItem.ico)})`;
+
+            if (!menuItemSlot) {
+                throw new Error(
+                    `No menu slot found for index ${i}. Current amount of available slots is: ${menuSlots.length}`,
+                );
+            }
+
+            applyUpdates(
+                f(
+                    null,
+                    {
+                        "data-id": i,
+                        "data-uID": menuItem.uID,
+                        "data-name": menuItem.name,
+                        "data-desc": menuItem.desc,
+                        "data-cost": menuItem.cost,
+                        "data-price": menuItem.price,
+                    },
+                    f("div", { style: { backgroundImage: menuItemTexture } }),
+                ),
+                menuItemSlot,
+            );
+        }
+    });
+}


### PR DESCRIPTION
Now we have basic rendering of the menu food items, using render-x and the new textures assets.

menu items are sadly being load using the old assets.js engine for entities management, so a future goal is to also remove this usage of the asset engine, as it no longer handle textures, ideally we don't want it to handle elements. 
